### PR TITLE
Fix installation of ember-cli-moment-shim addon

### DIFF
--- a/blueprints/ember-cli-moment-transform/index.js
+++ b/blueprints/ember-cli-moment-transform/index.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('ember-cli-moment-shim');
+    return this.addAddonToProject('ember-cli-moment-shim', '^0.7.2');
   }
 };


### PR DESCRIPTION
Because the addon was added as a Bower dependency, it caused version conflicts with some of the Bower dependencies of my Ember app. However, its Bower dependencies are only needed for developing (and testing) the addon.

See https://github.com/jasonmit/ember-cli-moment-shim/commit/20e54c0679afc6c63a046fe710e7984a46164e99#commitcomment-15483140.
